### PR TITLE
Switched raise to warn + updated tests and requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 fastparquet==2024.11.0
-matplotlib==3.10.1
+matplotlib==3.9.2
 model_tuner==0.0.29b1
-numpy==2.2.4
-pandas==2.2.3
+numpy==1.23.5
+pandas==2.2.2
 pytest==8.3.5
 pytest_cov==6.0.0
-scikit-learn==1.5.2
-scipy==1.15.2
+scikit-learn==1.5.1
+scipy==1.14.0
 seaborn==0.13.2
-tqdm==4.67.1
+tqdm==4.66.4
 ucimlrepo==0.0.7
 -e .

--- a/src/equiboots/EquiBootsClass.py
+++ b/src/equiboots/EquiBootsClass.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import numpy as np
 from tqdm import tqdm
+import warnings
 from sklearn.utils import resample
 from .metrics import (
     multi_class_classification_metrics,
@@ -385,7 +386,7 @@ class EquiBoots:
                     disparities[category][f"{metric_name}_ratio"] = ratio
                 else:
                     disparities[category][f"{metric_name}_ratio"] = -1
-                    raise Warning(
+                    warnings.warn(
                         "Reference metric value is zero returning negative value"
                     )
 

--- a/unittests/test_EquiBoots.py
+++ b/unittests/test_EquiBoots.py
@@ -2,6 +2,7 @@ import pandas as pd
 import numpy as np
 import inspect
 import pytest
+import warnings
 from src.equiboots import EquiBoots
 
 
@@ -258,3 +259,95 @@ def test_sample_group_unbalanced():
     group = fairness_df[fairness_df["race"] == "white"].index
     result = eq.sample_group(group, 1, 0, 50, [42], balanced=False)
     assert len(result) > 0
+
+
+def test_calculate_disparities_warns_on_zero_ref_value():
+    eq = EquiBoots(
+        y_true=np.array([1, 0]),
+        y_prob=np.array([0.9, 0.1]),
+        y_pred=np.array([1, 0]),
+        fairness_df=pd.DataFrame({"race": ["white", "black"]}),
+        fairness_vars=["race"],
+        reference_groups=["white"],
+        task="binary_classification",
+    )
+
+    # Create a fake metric dict with a zero reference value
+    metric_dict = {
+        "white": {"accuracy": 0.0},  # reference group with zero value
+        "black": {"accuracy": 0.8},
+    }
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")  # catch all warnings
+        disparities = eq.calculate_groups_disparities(metric_dict, "race")
+
+        # Make sure the warning was triggered
+        assert any("Reference metric value is zero" in str(warn.message) for warn in w)
+        assert disparities["black"]["accuracy_ratio"] == -1
+
+
+def test_default_reference_group_selection():
+    df = pd.DataFrame({"race": ["black"] * 60 + ["white"] * 40})
+    eq = EquiBoots(
+        y_true=np.random.randint(0, 2, 100),
+        y_prob=np.random.rand(100),
+        y_pred=(np.random.rand(100) > 0.5).astype(int),
+        fairness_df=df,
+        fairness_vars=["race"],
+        task="binary_classification",
+    )
+    assert eq.reference_groups["race"] == "black"
+
+
+def test_groups_slicer_regression():
+    y_true = np.random.rand(100)
+    y_pred = np.random.rand(100)
+    df = pd.DataFrame({"race": ["white"] * 100})
+    eq = EquiBoots(
+        y_true=y_true,
+        y_prob=y_pred,  # not used for regression
+        y_pred=y_pred,
+        fairness_df=df,
+        fairness_vars=["race"],
+        task="regression",
+    )
+    eq.grouper(groupings_vars=["race"])
+    sliced = eq.slicer("race")
+    assert isinstance(sliced, dict)
+    assert "white" in sliced
+    assert "y_true" in sliced["white"]
+
+
+def test_get_groups_metrics_multiclass():
+    y_true = np.random.choice([0, 1, 2], 100)
+    y_pred = np.random.choice([0, 1, 2], 100)
+    y_prob = np.random.dirichlet(np.ones(3), size=100)  # rows will sum to 1.0
+    df = pd.DataFrame({"race": ["white"] * 100})
+
+    eq = EquiBoots(
+        y_true=y_true,
+        y_prob=y_prob,
+        y_pred=y_pred,
+        fairness_df=df,
+        fairness_vars=["race"],
+        reference_groups=["white"],
+        task="multi_class_classification",
+    )
+    eq.grouper(["race"])
+    sliced = eq.slicer("race")
+    metrics = eq.get_metrics(sliced)
+    assert "white" in metrics
+
+
+def test_set_fix_seeds_invalid_type_raises():
+    eq = EquiBoots(
+        y_true=np.array([1, 0]),
+        y_prob=np.array([0.5, 0.5]),
+        y_pred=np.array([1, 0]),
+        fairness_df=pd.DataFrame({"race": ["white", "black"]}),
+        fairness_vars=["race"],
+        task="binary_classification",
+    )
+    with pytest.raises(ValueError):
+        eq.set_fix_seeds([1, "bad_seed", 3])


### PR DESCRIPTION
- Replaced raise with `warnings.warn` in disparity calculation for zero reference metrics
- Added unit test to confirm warning is triggered (`test_calculate_disparities_warns_on_zero_ref_value`)
- (+) multiclass test (`test_get_groups_metrics_multiclass`) by normalizing `y_prob` with `np.random.dirichlet`
- Updated and tested `requirements.txt` to ensure compatibility

**New coverage report:**

```text
---------- coverage: platform linux, python 3.11.0-final-0 -----------
Name                              Stmts   Miss  Cover
-----------------------------------------------------
src/equiboots/EquiBootsClass.py     158     12    92%
src/equiboots/__init__.py            18      0   100%
src/equiboots/logo.py                 1      0   100%
src/equiboots/metrics.py             72      0   100%
src/equiboots/plots.py              313     28    91%
-----------------------------------------------------
TOTAL                               562     40    93%
```