### PR TITLE
Effect Size Fix

### DIFF
--- a/src/equiboots/StatisticalTester.py
+++ b/src/equiboots/StatisticalTester.py
@@ -187,11 +187,6 @@ class StatisticalTester:
 
         test_func = self._test_implementations[config["test_type"]]
 
-        ## TODO: get tp,tn,fp,fn from metrics for each group
-        # then do omninous test
-        # if significant
-        # then do pairwise test
-        # return results
         metrics_CM = ["TP", "FP", "TN", "FN"]
         # Get the keys of the metrics dictionary
 
@@ -218,12 +213,10 @@ class StatisticalTester:
 
                 ref_comp_metrics = {**ref_metrics, **comp_metrics}
 
-                test_result = test_func(ref_comp_metrics, config)
-                results[group] = test_result
+                results[group] = test_func(ref_comp_metrics, config)
                 if results[group].is_significant:
                     effect_size = self._calculate_effect_size(ref_comp_metrics)
                     results[group].effect_size = effect_size
-                    pass
 
             return results
 

--- a/src/equiboots/StatisticalTester.py
+++ b/src/equiboots/StatisticalTester.py
@@ -200,7 +200,7 @@ class StatisticalTester:
         # omnibous test
         results["omnibus"] = test_func(metrics, config)
 
-        if results["omnibus"].is_signnificant:
+        if results["omnibus"].is_significant:
             effect_size = self._calculate_effect_size(metrics)
             results["omnibus"].effect_size = effect_size
 


### PR DESCRIPTION
We calc cramer's V for effect size when doing point wise statistical tests. This is done for pairwise and for omnibus calculations.

- Changing from pingouin to scipy association for cramer's v effect size calc
- Fixed a bug in the pair wise assessment where group_metric was being used instead of metric 
