### PR TITLE
Control Threshold Line, Multiple `y_lims` inside `eq_group_metrics_point_plot`

### DIFF
--- a/=0.13.0
+++ b/=0.13.0
@@ -1,0 +1,16 @@
+Collecting statsmodels
+  Using cached statsmodels-0.14.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (9.2 kB)
+Requirement already satisfied: numpy<3,>=1.22.3 in ./equi_venv/lib/python3.11/site-packages (from statsmodels) (1.26.0)
+Requirement already satisfied: scipy!=1.9.2,>=1.8 in ./equi_venv/lib/python3.11/site-packages (from statsmodels) (1.14.0)
+Requirement already satisfied: pandas!=2.1.0,>=1.4 in ./equi_venv/lib/python3.11/site-packages (from statsmodels) (2.2.2)
+Collecting patsy>=0.5.6 (from statsmodels)
+  Using cached patsy-1.0.1-py2.py3-none-any.whl.metadata (3.3 kB)
+Requirement already satisfied: packaging>=21.3 in ./equi_venv/lib/python3.11/site-packages (from statsmodels) (24.2)
+Requirement already satisfied: python-dateutil>=2.8.2 in ./equi_venv/lib/python3.11/site-packages (from pandas!=2.1.0,>=1.4->statsmodels) (2.9.0.post0)
+Requirement already satisfied: pytz>=2020.1 in ./equi_venv/lib/python3.11/site-packages (from pandas!=2.1.0,>=1.4->statsmodels) (2025.2)
+Requirement already satisfied: tzdata>=2022.7 in ./equi_venv/lib/python3.11/site-packages (from pandas!=2.1.0,>=1.4->statsmodels) (2025.2)
+Requirement already satisfied: six>=1.5 in ./equi_venv/lib/python3.11/site-packages (from python-dateutil>=2.8.2->pandas!=2.1.0,>=1.4->statsmodels) (1.17.0)
+Using cached statsmodels-0.14.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (10.8 MB)
+Using cached patsy-1.0.1-py2.py3-none-any.whl (232 kB)
+Installing collected packages: patsy, statsmodels
+Successfully installed patsy-1.0.1 statsmodels-0.14.4

--- a/notebooks/equi_boots_plots.ipynb
+++ b/notebooks/equi_boots_plots.ipynb
@@ -434,7 +434,7 @@
     "\n",
     "\n",
     "boots_sex_data = eq2.slicer(\"sex\")\n",
-    "sex_metrics = eq2.get_metrics(boots_sex_data)\n"
+    "sex_metrics = eq2.get_metrics(boots_sex_data)"
    ]
   },
   {
@@ -508,11 +508,7 @@
    "source": [
     "eqb.eq_group_metrics_plot(\n",
     "    group_metrics=race_metrics,\n",
-    "    metric_cols=[\n",
-    "        \"Accuracy\",\n",
-    "        \"Recall\",\n",
-    "        \"ROC AUC\"\n",
-    "    ],\n",
+    "    metric_cols=[\"Accuracy\", \"Recall\", \"ROC AUC\"],\n",
     "    name=\"race\",\n",
     "    categories=\"all\",\n",
     "    figsize=(12, 4),\n",
@@ -652,7 +648,7 @@
     "}\n",
     "stat_test_results = eq.analyze_statistical_significance(\n",
     "    race_metrics_3, \"race\", test_config\n",
-    ")\n"
+    ")"
    ]
   },
   {
@@ -685,6 +681,8 @@
     "    raw_metrics=True,\n",
     "    show_grid=True,\n",
     "    y_lim=(0, 1),\n",
+    "    show_reference=True,\n",
+    "    y_lims={(0, 0): (0.40, 0.6), (0, 1): (0.40, 0.6)},\n",
     ")"
    ]
   },
@@ -915,18 +913,11 @@
     "    show_grid=False,\n",
     ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "equiboots",
+   "display_name": "equi_venv",
    "language": "python",
    "name": "python3"
   },
@@ -940,7 +931,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.13"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/src/equiboots/plots.py
+++ b/src/equiboots/plots.py
@@ -329,16 +329,19 @@ def plot_with_layout(
 
 
 def add_plot_threshold_lines(
-    ax: plt.Axes, lower: float, upper: float, xmax: float
+    ax: plt.Axes,
+    lower: float,
+    upper: float,
+    xmax: float,
+    show_reference: bool = True,
 ) -> None:
-    """Add disparity threshold lines to the plot."""
-    ax.hlines(
-        [lower, 1.0, upper],
-        xmin=-0.5,
-        xmax=xmax + 0.5,
-        ls=":",
-        colors=["red", "black", "red"],
-    )
+    """Add threshold lines to the plot, optionally showing y=1 reference line."""
+    y_values = [lower, upper]
+    colors = ["red", "red"]
+    if show_reference:
+        y_values.insert(1, 1.0)
+        colors.insert(1, "black")
+    ax.hlines(y_values, xmin=-0.5, xmax=xmax + 0.5, ls=":", colors=colors)
     ax.set_xlim(-0.5, xmax + 0.5)
 
 
@@ -1370,6 +1373,8 @@ def eq_group_metrics_point_plot(
     leg_cols: int = 3,
     raw_metrics: bool = False,
     statistical_tests: dict = None,
+    show_reference: bool = True,
+    y_lims: Optional[Dict[Tuple[int, int], Tuple[float, float]]] = None,
     **plot_kwargs: Dict[str, Union[str, float]],
 ) -> None:
     """
@@ -1386,7 +1391,8 @@ def eq_group_metrics_point_plot(
     leg_cols        : int              - no. of columns in legend
     raw_metrics     : bool             - Treat metrics as raw; not metric ratios
     """
-    all_groups = sorted({group for groups in group_metrics for group in groups})
+    # Determine all unique group names
+    all_groups = sorted(set().union(*(gm.keys() for gm in group_metrics)))
 
     # Shared setup
     n_cols = len(category_names)
@@ -1480,9 +1486,12 @@ def eq_group_metrics_point_plot(
             else:
                 ax.set_ylabel("")
 
-            ax.set_ylim(y_lim)
+            if y_lims and (i, j) in y_lims:
+                ax.set_ylim(y_lims[(i, j)])
+            else:
+                ax.set_ylim(y_lim)
             ax.grid(show_grid)
-            add_plot_threshold_lines(ax, lower, upper, len(groups))
+            add_plot_threshold_lines(ax, lower, upper, len(groups), show_reference)
             ax.set_xlim(-0.5, len(groups) - 0.5)
 
     for row_idx in range(len(metric_cols)):


### PR DESCRIPTION
- Gave end-user flexibility inside `add_plot_threshold_lines()` :
- `show_reference` 
- control multiple `y_lims` using dictionary of tuples:
  - Example:
    ```python
       y_lims = {(0,0): (0.70, 1.0), (0,1): (0.70, 1.0)}
    ```
    This means, take positional arguments from `metrics_cols` and `category_names`, respectively and match them here:
    
        metric_cols=[
            "Accuracy",
            "Precision",
            "Recall",
        ],
        category_names=["race", "sex"],