### PR TITLE
Add group-specific threshold utilities for model healing

### DIFF
--- a/notebooks/equi_boots_plots.ipynb
+++ b/notebooks/equi_boots_plots.ipynb
@@ -394,6 +394,13 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -546,29 +553,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "eqb.eq_group_metrics_plot(\n",
-    "    group_metrics=race_metrics,\n",
-    "    metric_cols=[\"Accuracy\", \"Recall\", \"ROC AUC\"],\n",
-    "    name=\"race\",\n",
-    "    categories=\"all\",\n",
-    "    figsize=(12, 4),\n",
-    "    plot_type=\"boxplot\",\n",
-    "    color_by_group=True,\n",
-    "    show_grid=False,\n",
-    "    strict_layout=True,\n",
-    "    save_path=\"./images\",\n",
-    "    show_pass_fail=False,\n",
-    "    # y_lim=(-2, 4),\n",
-    "    # disparity_thresholds=[0.9, 1.2],\n",
-    ")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -714,13 +698,13 @@
    "source": [
     "# Run with custom y_lim and adjusted thresholds\n",
     "eqb.eq_group_metrics_point_plot(\n",
-    "    group_metrics=[race_metrics_3, sex_metrics_3],\n",
+    "    group_metrics=[race_metrics_3],\n",
     "    metric_cols=[\n",
     "        \"Accuracy\",\n",
     "        \"Precision\",\n",
     "        \"Recall\",\n",
     "    ],\n",
-    "    category_names=[\"race\", \"sex\"],\n",
+    "    category_names=[\"race\"],\n",
     "    figsize=(6, 8),\n",
     "    include_legend=True,\n",
     "    plot_thresholds=(0.9, 1.1),\n",
@@ -728,6 +712,7 @@
     "    show_grid=True,\n",
     "    show_reference=True,\n",
     "    statistical_tests=stat_test_results,\n",
+    "    y_lims={(0, 0): (0.4, 0.6), (1, 0): (0.4, 0.6), (2, 0): (0.4, 0.6)},\n",
     ")"
    ]
   },
@@ -802,6 +787,209 @@
    "source": [
     "disa_metrics_df = eqb.metrics_dataframe(metrics_data=dispa)\n",
     "disa_metrics_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Find Matching Thresholds for Groups"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "group_thresholds_race = eqb.find_group_thresholds(\n",
+    "    y_true=y_true,\n",
+    "    y_prob=y_prob,\n",
+    "    reference_group=\"white\",\n",
+    "    group_vec=fairness_df[\"race\"],\n",
+    "    ref_metrics=None,\n",
+    "    threshold_range=(0.1, 0.9),\n",
+    "    n_steps=100,\n",
+    "    default_threshold=0.5,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Apply Grouped Thresholds to Make New Predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Extract race labels for each instance in the dataset\n",
+    "race_labels = fairness_df[\"race\"].values\n",
+    "\n",
+    "# Get new predictions using group-specific thresholds\n",
+    "y_pred_grouped_thresh = eqb.grouped_threshold_predict(\n",
+    "    y_prob,\n",
+    "    race_labels,\n",
+    "    group_thresholds_race,\n",
+    ")\n",
+    "\n",
+    "# Save new predictions in the fairness DataFrame\n",
+    "fairness_df[\"y_pred_grouped_thresh\"] = y_pred_grouped_thresh"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create New EquiBoots Object for Adjusted Predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add true labels and predicted probabilities\n",
+    "fairness_df[\"y_true\"] = y_true  # holds the correct answers/actual labels\n",
+    "fairness_df[\"y_prob\"] = y_prob  # model's predicted probabilities\n",
+    "\n",
+    "X_test = fairness_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a new EquiBoots object using the adjusted predictions\n",
+    "eq_adjusted = eqb.EquiBoots(\n",
+    "    y_true=fairness_df[\"y_true\"],  # True labels\n",
+    "    y_prob=fairness_df[\"y_prob\"],  # Predicted probabilities\n",
+    "    y_pred=fairness_df[\"y_pred_grouped_thresh\"],  # Adjusted predictions\n",
+    "    fairness_df=fairness_df,  # Dataset with sensitive attributes\n",
+    "    fairness_vars=[\"race\"],  # Focus fairness analysis on race\n",
+    ")\n",
+    "\n",
+    "# Re-group the data by race (prepares for fairness slicing)\n",
+    "eq_adjusted.grouper(groupings_vars=[\"race\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Slice and Evaluate New Metrics by Race"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Extract subgroup data by race\n",
+    "sliced_race_data_adjusted = eq_adjusted.slicer(\"race\")\n",
+    "\n",
+    "# Compute fairness performance metrics for each racial group using adjusted predictions\n",
+    "race_metrics_adjusted = eq_adjusted.get_metrics(sliced_race_data_adjusted)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Run Statistical Significance Tests for Adjusted Predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create adjusted predictions using race-specific thresholds\n",
+    "race_labels = fairness_df[\"race\"].values\n",
+    "y_pred_grouped_thresh = eqb.grouped_threshold_predict(\n",
+    "    y_prob, race_labels, group_thresholds_race\n",
+    ")\n",
+    "\n",
+    "# Update fairness_df with adjusted predictions\n",
+    "fairness_df[\"y_pred_grouped_thresh\"] = y_pred_grouped_thresh\n",
+    "\n",
+    "# Instantiate new EquiBoots object using thresholded predictions\n",
+    "eq_adjusted = eqb.EquiBoots(\n",
+    "    y_true=fairness_df[\"y_true\"],\n",
+    "    y_prob=fairness_df[\"y_prob\"],\n",
+    "    y_pred=fairness_df[\"y_pred_grouped_thresh\"],\n",
+    "    fairness_df=fairness_df,\n",
+    "    fairness_vars=[\"race\"],\n",
+    ")\n",
+    "\n",
+    "# Group by race for adjusted metrics\n",
+    "eq_adjusted.grouper(groupings_vars=[\"race\"])\n",
+    "\n",
+    "# Evaluate adjusted metrics by race\n",
+    "sliced_race_data_adjusted = eq_adjusted.slicer(\"race\")\n",
+    "race_metrics_adjusted = eq_adjusted.get_metrics(sliced_race_data_adjusted)\n",
+    "\n",
+    "# Run statistical significance tests on adjusted race metrics\n",
+    "test_config = {\n",
+    "    \"test_type\": \"chi_square\",\n",
+    "    \"alpha\": 0.05,\n",
+    "    \"adjust_method\": \"bonferroni\",\n",
+    "    \"confidence_level\": 0.95,\n",
+    "    \"classification_task\": \"binary_classification\",\n",
+    "}\n",
+    "stat_test_results_adjusted = eq_adjusted.analyze_statistical_significance(\n",
+    "    race_metrics_adjusted, \"race\", test_config\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Combine Adjusted and Original Metrics for Final Plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Combine updated race metrics and original sex metrics for a final fairness plot\n",
+    "overall_stat_results_adjusted = {\n",
+    "    \"race\": stat_test_results_adjusted,  # Adjusted test results for race\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot the group performance metrics for both race (adjusted) and sex (original)\n",
+    "eqb.eq_group_metrics_point_plot(\n",
+    "    group_metrics=[race_metrics_adjusted],  # Grouped metrics to compare\n",
+    "    metric_cols=[\"Accuracy\", \"Precision\", \"Recall\"],  # Metrics to plot\n",
+    "    category_names=[\"race\"],  # Categories to compare\n",
+    "    figsize=(8, 8),  # Size of the plot\n",
+    "    include_legend=True,  # Show legend\n",
+    "    plot_thresholds=(0.9, 1.1),  # Highlight near-equality\n",
+    "    raw_metrics=True,  # Use raw (not normalized) values\n",
+    "    show_grid=True,  # Add grid to plot\n",
+    "    y_lim=(0, 1),  # Set y-axis limits\n",
+    "    statistical_tests=overall_stat_results_adjusted,  # Display statistical test results\n",
+    "    y_lims={(0, 0): (0.4, 0.6), (1, 0): (0.4, 0.6), (2, 0): (0.4, 0.6)},\n",
+    ")"
    ]
   },
   {
@@ -905,53 +1093,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Regression Mock-Up"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "## Generate synthetic regression-like data\n",
-    "np.random.seed(42)\n",
-    "y_true = np.random.normal(loc=50, scale=10, size=1000)  ## continuous target\n",
-    "y_pred = y_true + np.random.normal(\n",
-    "    loc=0, scale=5, size=1000\n",
-    ")  # predicted value with noise\n",
-    "\n",
-    "# Not really 'prob', but using this slot for predicted values\n",
-    "y_prob = y_pred\n",
-    "\n",
-    "race = (\n",
-    "    np.random.RandomState(3)\n",
-    "    .choice([\"white\", \"black\", \"asian\", \"hispanic\"], 1000)\n",
-    "    .reshape(-1, 1)\n",
-    ")\n",
-    "sex = np.random.choice([\"M\", \"F\"], 1000).reshape(-1, 1)\n",
-    "\n",
-    "fairness_df = pd.DataFrame(\n",
-    "    data=np.concatenate((race, sex), axis=1), columns=[\"race\", \"sex\"]\n",
-    ")\n",
-    "\n",
-    "# Initialize and process groups\n",
-    "eq3 = eqb.EquiBoots(\n",
-    "    y_true=y_true,\n",
-    "    y_prob=y_prob,\n",
-    "    y_pred=y_pred,\n",
-    "    task=\"regression\",\n",
-    "    fairness_df=fairness_df,\n",
-    "    fairness_vars=[\"race\", \"sex\"],\n",
-    ")\n",
-    "eq3.grouper(groupings_vars=[\"race\", \"sex\"])\n",
-    "sliced_data_2 = eq3.slicer(\"race\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Bootstrapped Metrics Forest Plots"
    ]
   },
@@ -973,7 +1114,7 @@
     "    metric=\"ROC AUC\",\n",
     "    reference_group=\"white\",\n",
     "    save_path=\"images\",\n",
-    "    filename=\"bootstrapped_roc_auc_forest_race_metrics\",\n",
+    "    filename=\"bootstrapped_roc_auc_calibration\",\n",
     ")"
    ]
   },
@@ -995,8 +1136,55 @@
     "    reference_group=\"white\",\n",
     "    metric=\"Precision\",\n",
     "    save_path=\"images\",\n",
-    "    filename=\"bootstrapped_pr_auc_forest_race_metrics\",\n",
+    "    filename=\"bootstrapped_pr_auc_forest\",\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Regression Mock-Up"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Generate synthetic regression-like data\n",
+    "np.random.seed(42)\n",
+    "y_true_reg = np.random.normal(loc=50, scale=10, size=1000)  ## continuous target\n",
+    "y_pred_reg = y_true_reg + np.random.normal(\n",
+    "    loc=0, scale=5, size=1000\n",
+    ")  # predicted value with noise\n",
+    "\n",
+    "# Not really 'prob', but using this slot for predicted values\n",
+    "y_prob_reg = y_pred_reg\n",
+    "\n",
+    "race = (\n",
+    "    np.random.RandomState(3)\n",
+    "    .choice([\"white\", \"black\", \"asian\", \"hispanic\"], 1000)\n",
+    "    .reshape(-1, 1)\n",
+    ")\n",
+    "sex = np.random.choice([\"M\", \"F\"], 1000).reshape(-1, 1)\n",
+    "\n",
+    "fairness_df = pd.DataFrame(\n",
+    "    data=np.concatenate((race, sex), axis=1), columns=[\"race\", \"sex\"]\n",
+    ")\n",
+    "\n",
+    "# Initialize and process groups\n",
+    "eq3 = eqb.EquiBoots(\n",
+    "    y_true=y_true_reg,\n",
+    "    y_prob=y_prob_reg,\n",
+    "    y_pred=y_pred_reg,\n",
+    "    task=\"regression\",\n",
+    "    fairness_df=fairness_df,\n",
+    "    fairness_vars=[\"race\", \"sex\"],\n",
+    ")\n",
+    "eq3.grouper(groupings_vars=[\"race\", \"sex\"])\n",
+    "sliced_data_2 = eq3.slicer(\"race\")"
    ]
   },
   {
@@ -1058,7 +1246,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "equi_venv",
+   "display_name": "equi_venv_311",
    "language": "python",
    "name": "python3"
   },
@@ -1072,7 +1260,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/notebooks/threshold_model_healing_colab.ipynb
+++ b/notebooks/threshold_model_healing_colab.ipynb
@@ -1,0 +1,1766 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "EWNzbca5Mf0x"
+   },
+   "source": [
+    "# Bias and Fairness Assessment (Binary Classification: Adult Income)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "mQKjeKFGV4ut"
+   },
+   "source": [
+    "Assessing Machine Learning models for bias and fairness is of great importance:\n",
+    "\n",
+    "- Prevent Discrimination\n",
+    "  - Avoid unfair treatment based on protected attributes.\n",
+    "\n",
+    "- Meet Legal Standards\n",
+    "  - Ensure compliance with laws and anti-discrimination acts.\n",
+    "\n",
+    "- Build Trust\n",
+    "  - Fair models are more accepted by users, stakeholders, and regulators.\n",
+    "\n",
+    "- Expose Hidden Gaps\n",
+    "  - Surface performance differences across demographic subgroups.\n",
+    "\n",
+    "- Promote Ethical AI\n",
+    "  - Prevent reinforcement of societal or historical biases in data.\n",
+    "\n",
+    "- Enable Accountability\n",
+    "  - Make models more transparent and open to external review.\n",
+    "\n",
+    "- Guide Fairness Fixes\n",
+    "  - Identify where to apply debiasing or fairness-enhancing techniques"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "c2AbxsXsMkPj"
+   },
+   "source": [
+    "## Dataset Overview: UCI Adult Income Dataset\n",
+    "The **Adult Income dataset** (also known as the **Census Income** dataset) originates from the **UCI Machine Learning Repository**. It was extracted from the 1994 U.S. Census database and is widely used for benchmarking classification models, especially in fairness and bias research.\n",
+    "\n",
+    "The task is to **predict whether an individual earns more than $50K per year** based on features such as age, education, occupation, and marital status.\n",
+    "\n",
+    "- Target variable: income (binary: <=50K or >50K)\n",
+    "\n",
+    "- Samples: 48,842\n",
+    "\n",
+    "- Features: 14 demographic and employment-related attributes\n",
+    "\n",
+    "- Use case: Benchmarking algorithms, fairness audits, and bias mitigation\n",
+    "\n",
+    "Due to its inclusion of sensitive attributes (e.g., sex, race), it’s commonly used in studies evaluating algorithmic fairness and disparate impact.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5wfzEPOyMqeP"
+   },
+   "source": [
+    "# Modeling"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ulxJaIRQMlwn"
+   },
+   "source": [
+    "In this notebook, we’ll train an XGBoost model to predict whether an individual’s annual income exceeds \\$50K and then evaluate its performance and fairness across different demographic groups."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "_IGcBI4ZMoXk"
+   },
+   "source": [
+    "### Step 1: Install and import dependencies\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ! pip install equiboots"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "FAxWExLnMuRg",
+    "outputId": "b6f5f9d8-0915-4a9b-899c-d43de1f8c10f"
+   },
+   "outputs": [],
+   "source": [
+    "# ! pip install ucimlrepo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "MirLIXB9MxFN"
+   },
+   "outputs": [],
+   "source": [
+    "from ucimlrepo import fetch_ucirepo\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from sklearn.preprocessing import LabelEncoder\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from xgboost import XGBClassifier\n",
+    "from sklearn.metrics import classification_report"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ZfFb02NyMyBn"
+   },
+   "outputs": [],
+   "source": [
+    "# fetch dataset\n",
+    "adult = fetch_ucirepo(id=2)\n",
+    "adult = adult.data.features.join(adult.data.targets, how=\"inner\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 143
+    },
+    "id": "GoCXwqsQTCQQ",
+    "outputId": "ab092335-f5d5-4641-bc98-203d3e315e89"
+   },
+   "outputs": [],
+   "source": [
+    "adult.head(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "xMQ5N47vMzXZ"
+   },
+   "source": [
+    "## Basic Preprocessing Steps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yYBb5DsxMz8T"
+   },
+   "source": [
+    "### 1. Drop missing values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "bF_DtdPTM1Yy"
+   },
+   "outputs": [],
+   "source": [
+    "# Drop missing values\n",
+    "adult.dropna(inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-p7NlTeJNstX"
+   },
+   "source": [
+    "### 2. Copy DataFrame for posterity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "akVIVbXmNqTw"
+   },
+   "outputs": [],
+   "source": [
+    "df = adult.copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 240
+    },
+    "id": "eXRmeg_8wiA2",
+    "outputId": "a459de22-86f4-4595-b870-151d42296e46"
+   },
+   "outputs": [],
+   "source": [
+    "adult[\"income\"].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Fbu-MFeMM2sz"
+   },
+   "source": [
+    "### 3. Encode categorical variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "K036CclmWbPl"
+   },
+   "outputs": [],
+   "source": [
+    "def outcome_merge(val):\n",
+    "    if val == \"<=50K\" or val == \"<=50K.\":\n",
+    "        return 0\n",
+    "    else:\n",
+    "        return 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "N74NyjgtWRMr"
+   },
+   "outputs": [],
+   "source": [
+    "df[\"income\"] = df[\"income\"].apply(outcome_merge)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 143
+    },
+    "id": "PE-G6TJTbLpB",
+    "outputId": "216ceb46-3baa-4bcc-ba5a-dfd6481ac8a1"
+   },
+   "outputs": [],
+   "source": [
+    "#  sex, count and percentages above_50k\n",
+    "\n",
+    "income_by_sex = df.groupby(\"sex\")[\"income\"].agg(\n",
+    "    [\"count\", lambda x: (x.sum() / x.count()) * 100]\n",
+    ")\n",
+    "income_by_sex.columns = [\"count\", \"percentage_above_50k\"]\n",
+    "income_by_sex"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 237
+    },
+    "id": "bHf0GSvkaZge",
+    "outputId": "d78cfe79-a082-4589-94ff-27005d4b297f"
+   },
+   "outputs": [],
+   "source": [
+    "#  race, count and percentages above_50k\n",
+    "\n",
+    "income_by_race = df.groupby(\"race\")[\"income\"].agg(\n",
+    "    [\"count\", lambda x: (x.sum() / x.count()) * 100]\n",
+    ")\n",
+    "income_by_race.columns = [\"count\", \"percentage_above_50k\"]\n",
+    "income_by_race"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "SBAi0x6IM5Yv"
+   },
+   "source": [
+    "### 4. Split the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Lfe5t6IZM60e"
+   },
+   "outputs": [],
+   "source": [
+    "# Split data\n",
+    "X = df.drop(\"income\", axis=1)\n",
+    "y = df[\"income\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "DVEzdrADAzP9"
+   },
+   "outputs": [],
+   "source": [
+    "for col in X.columns:\n",
+    "    if isinstance(X[col], object):\n",
+    "        X[col] = X[col].astype(\"category\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "lmUyh5dzM8dU"
+   },
+   "outputs": [],
+   "source": [
+    "X_train, X_test, y_train, y_test = train_test_split(\n",
+    "    X,\n",
+    "    y,\n",
+    "    test_size=0.2,\n",
+    "    random_state=42,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 178
+    },
+    "id": "QTlGNyrHwIPW",
+    "outputId": "568a9258-cb41-42e1-9877-28cb3af24640"
+   },
+   "outputs": [],
+   "source": [
+    "y_train.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "4uRLCghYM9Ub"
+   },
+   "source": [
+    "## Train XGBoost Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 257
+    },
+    "id": "ifiKclAeM-1H",
+    "outputId": "df6a9eff-9c1a-4c1a-f1c3-1e2f2930a884"
+   },
+   "outputs": [],
+   "source": [
+    "model = XGBClassifier(eval_metric=\"logloss\", random_state=42, enable_categorical=True)\n",
+    "model.fit(X_train, y_train)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "wqe2kl-7NAhB"
+   },
+   "source": [
+    "## Evaluate XGBoost Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "NvULzSB5NCMn",
+    "outputId": "897bae66-e5f3-4e1d-ce64-c742c3d2602c"
+   },
+   "outputs": [],
+   "source": [
+    "y_pred = model.predict(X_test)\n",
+    "y_prob = model.predict_proba(X_test)\n",
+    "print(classification_report(y_test, y_pred))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "VKydvDxLThP9"
+   },
+   "source": [
+    "# Bias and Fairness Analysis with EquiBoots\n",
+    "\n",
+    "**Equiboots supports a point estimate fairness analysis on a model's operating point (e.g., optimal threshold) as well as on multiple bootstraps with replacement.**\n",
+    "\n",
+    "\n",
+    "To initialize an analysis with equiboots:\n",
+    "\n",
+    "1. Define a fairness Dataframe with the variables of interest.\n",
+    "2. Initialize an equiboots object using:\n",
+    "    - Ground truth (y_true)\n",
+    "    - Model probabilities (y_prob)\n",
+    "    - Model predictions (y_pred)\n",
+    "3. Identify the columns/variables that we will be assessing (e.g., race, sex)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "id0rzf9HTgd1"
+   },
+   "outputs": [],
+   "source": [
+    "import equiboots as eqb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "RplCUsl2TzNB"
+   },
+   "source": [
+    "# Points Estimates\n",
+    "## Overview:\n",
+    "This code performs a step-by-step fairness analysis of a machine learning model using EquiBoots. First, it generates predictions and probabilities for the test data, converts the true labels to a NumPy array, and ensures the sensitive group variables ('race' and 'sex') are in string format. Then, it creates a new table (DataFrame) to track group-level attributes and adds both the true labels and predicted probabilities for later fairness comparisons. The EquiBoots tool is initialized with these inputs and used to group data by race and sex. Fairness metrics such as accuracy, precision, recall, and specificity are calculated for each group. A statistical significance test (Chi-square with Bonferroni correction) is then configured and run to determine whether differences between groups are meaningful. The code also defines and uses a custom function to compute specificity. Using the \"White\" group as a reference, it calculates baseline performance metrics and then identifies the best decision threshold for each racial group that minimizes the difference from the reference. These steps together build a foundation for evaluating and improving model fairness across demographic groups.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "6nBcFtG47yZP"
+   },
+   "source": [
+    "##  Unadjusted Fairness Metrics by Race and Sex  \n",
+    "This section visualizes the **original (unadjusted)** model predictions across **race** and **sex**.  \n",
+    "We'll plot **Accuracy**, **Precision**, and **Recall**, along with results from statistical significance testing.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "LHp1UkeJcZM7"
+   },
+   "source": [
+    "##Step 1: Organize Statistical Test Results\n",
+    "Prepare the significance test results for race and sex groups so we can include them in the performance plot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "nxopIzrH4GZy"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "WZDhrQZvTesJ",
+    "outputId": "b1a2768a-d101-4e89-ff8c-6839169bbeef"
+   },
+   "outputs": [],
+   "source": [
+    "# get predictions and true values\n",
+    "y_pred = model.predict(X_test)\n",
+    "y_prob = model.predict_proba(X_test)[:, 1]\n",
+    "y_test = y_test.to_numpy()\n",
+    "\n",
+    "X_test[[\"race\", \"sex\"]] = X_test[[\"race\", \"sex\"]].astype(str)\n",
+    "\n",
+    "\n",
+    "# Create fairness DataFrame\n",
+    "fairness_df = X_test[[\"race\", \"sex\"]].reset_index()\n",
+    "\n",
+    "eq = eqb.EquiBoots(\n",
+    "    y_true=y_test,\n",
+    "    y_prob=y_prob,\n",
+    "    y_pred=y_pred,\n",
+    "    fairness_df=fairness_df,\n",
+    "    fairness_vars=[\"race\", \"sex\"],\n",
+    ")\n",
+    "\n",
+    "# grouping by variables' groups (e.g., Male, Female, etc)\n",
+    "eq.grouper(groupings_vars=[\"race\", \"sex\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yUgq0r9vcguk"
+   },
+   "source": [
+    "##Step 2: Plot Performance Metrics for Race and Sex (Unadjusted)\n",
+    "Visualize the model's performance for different demographic groups. This plot shows Accuracy, Precision, and Recall grouped by race and sex using the unadjusted predictions. Statistical test results are added to highlight significant differences."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "MRCs0MSg6RJI"
+   },
+   "outputs": [],
+   "source": [
+    "# Compute metrics by race\n",
+    "sliced_race_data = eq.slicer(\n",
+    "    \"race\"\n",
+    ")  # tells eq to filter and organize the data by race(assigns new variable)\n",
+    "race_metrics = eq.get_metrics(\n",
+    "    sliced_race_data\n",
+    ")  # caculates fairness for each race; data is stored in race_metrics\n",
+    "# Compute metrics by sex\n",
+    "sliced_sex_data = eq.slicer(\"sex\")  # filters and organize data by sex\n",
+    "sex_metrics = eq.get_metrics(sliced_sex_data)  # calculates fairness for sex"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "HGG4JEzo6ygg"
+   },
+   "outputs": [],
+   "source": [
+    "# Config for statistical testing\n",
+    "test_config = {\n",
+    "    \"test_type\": \"chi_square\",\n",
+    "    \"alpha\": 0.05,\n",
+    "    \"adjust_method\": \"bonferroni\",\n",
+    "    \"confidence_level\": 0.95,\n",
+    "    \"classification_task\": \"binary_classification\",\n",
+    "}\n",
+    "\n",
+    "# Run fairness tests\n",
+    "stat_test_results_race = eq.analyze_statistical_significance(\n",
+    "    race_metrics, \"race\", test_config\n",
+    ")\n",
+    "stat_test_results_sex = eq.analyze_statistical_significance(\n",
+    "    sex_metrics, \"sex\", test_config\n",
+    ")\n",
+    "\n",
+    "# Store results\n",
+    "overall_stat_results = {\n",
+    "    \"sex\": stat_test_results_sex,\n",
+    "    \"race\": stat_test_results_race,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 965
+    },
+    "id": "RwGRiu6sX0OF",
+    "outputId": "97371afd-f884-4642-b7d1-72e8748b319c"
+   },
+   "outputs": [],
+   "source": [
+    "# Plot original (unadjusted) performance metrics by race and sex\n",
+    "eqb.eq_group_metrics_point_plot(\n",
+    "    group_metrics=[race_metrics, sex_metrics],  # Metrics by group\n",
+    "    metric_cols=[\"Accuracy\", \"Precision\", \"Recall\"],  # Which metrics to display\n",
+    "    category_names=[\"race\", \"sex\"],  # Groups being compared\n",
+    "    figsize=(6, 8),  # Plot size\n",
+    "    include_legend=True,  # Include legend for clarity\n",
+    "    plot_thresholds=(0.9, 1.1),  # Highlight near-equal thresholds\n",
+    "    raw_metrics=True,  # Show actual values (not normalized)\n",
+    "    show_grid=True,  # Show grid for readability\n",
+    "    y_lim=(0, 1),  # Y-axis limit\n",
+    "    statistical_tests=overall_stat_results,  # Include statistical significance tests\n",
+    "    y_lims={  # Customize Y-axis for each group/metric\n",
+    "        (\"sex\", \"Accuracy\"): (0.70, 1.0),\n",
+    "        (\"sex\", \"Precision\"): (0.70, 1.0),\n",
+    "        (\"sex\", \"Recall\"): (0.70, 1.0),\n",
+    "        (\"race\", \"Accuracy\"): (0.70, 1.0),\n",
+    "        (\"race\", \"Precision\"): (0.70, 1.0),\n",
+    "        (\"race\", \"Recall\"): (0.70, 1.0),\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "fmZ2vysdZUQ7"
+   },
+   "source": [
+    "#**Calculating best thresholds possible**\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aw_ZQ7cQZewp"
+   },
+   "source": [
+    "## *Best thresholds for race and sex*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "nSz1Qjf75mjh"
+   },
+   "outputs": [],
+   "source": [
+    "# Create a DataFrame(fairness_df) to track group attributes\n",
+    "fairness_df = X_test[[\"race\", \"sex\"]].reset_index(\n",
+    "    drop=True\n",
+    ")  # creates new data frame and table to race and sex for fairness analysis\n",
+    "\n",
+    "# Add true labels and predicted probabilities\n",
+    "fairness_df[\"y_true\"] = y_test  # holds the correct answers/actual labels\n",
+    "fairness_df[\"y_prob\"] = y_prob  # model's predicted probabilities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "5lrv80ff51YZ",
+    "outputId": "e1663ff5-a142-4d79-a663-c0cc1fe7140d"
+   },
+   "outputs": [],
+   "source": [
+    "# Initialize EquiBoots with labels and group information\n",
+    "eq = eqb.EquiBoots(  # maybe ask for help\n",
+    "    y_true=y_test,  # actual correct answers/labels\n",
+    "    y_prob=y_prob,  # predicted probabilities\n",
+    "    y_pred=y_pred,  # predicted class labels\n",
+    "    fairness_df=fairness_df,  # table with race and sex info of each person\n",
+    "    # figure out what fairness_vars is\n",
+    "    fairness_vars=[\n",
+    "        \"race\",\n",
+    "        \"sex\",\n",
+    "    ],  # tells equiboots to use race and sex when analyzing fairness\n",
+    ")\n",
+    "\n",
+    "# Group the data by race and sex for analysis\n",
+    "eq.grouper(\n",
+    "    groupings_vars=[\"race\", \"sex\"]\n",
+    ")  # groups data by race and sex so Equiboots analyzes how fairly the model performs for each group"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "55f4eWuF5Ygh"
+   },
+   "source": [
+    "## Step 1: Generate Model Predictions and Probabilities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "vNlxgwlsuQHL"
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.metrics import (\n",
+    "    accuracy_score,\n",
+    "    precision_score,\n",
+    "    recall_score,\n",
+    "    confusion_matrix,\n",
+    ")\n",
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "# Function to compute specificity\n",
+    "def specificity_score(y_true, y_pred):\n",
+    "    tn, fp, fn, tp = confusion_matrix(y_true, y_pred).ravel()\n",
+    "    return tn / (tn + fp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "nn4boA37whaz"
+   },
+   "outputs": [],
+   "source": [
+    "# Generate predictions and predicted probabilities\n",
+    "# Ensure 'race' and 'sex' are category dtype for XGBoost\n",
+    "X_test[[\"race\", \"sex\"]] = X_test[[\"race\", \"sex\"]].astype(\"category\")\n",
+    "\n",
+    "y_pred = model.predict(X_test)\n",
+    "y_prob = model.predict_proba(X_test)[:, 1]\n",
+    "# y_test = y_test.to_numpy()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "UEw_thto68tW"
+   },
+   "source": [
+    "## Step 2: Compute Reference Metrics\n",
+    "## 1.White Group"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "IEqS36TX7BIY"
+   },
+   "outputs": [],
+   "source": [
+    "# Use the \"White\" group as reference at threshold = 0.5\n",
+    "reference_group = \"White\"\n",
+    "ref_indices = (\n",
+    "    fairness_df[\"race\"] == reference_group\n",
+    ")  # tells us which people in the data belong to the White group\n",
+    "ref_pred = (fairness_df[\"y_prob\"][ref_indices] >= 0.5).astype(\n",
+    "    int\n",
+    ")  # applies probability of 0.5 to White group\n",
+    "ref_y_true = fairness_df[\"y_true\"][\n",
+    "    ref_indices\n",
+    "]  # grabs correct answers for White group (saves in ref_y_true)\n",
+    "\n",
+    "# Compute Baseline Metrics\n",
+    "ref_accuracy = accuracy_score(\n",
+    "    ref_y_true, ref_pred\n",
+    ")  # correct predictions #y_true = true values\n",
+    "ref_precision = precision_score(ref_y_true, ref_pred)  # how many tp there are\n",
+    "ref_recall = recall_score(ref_y_true, ref_pred)  # how mant tp the model caught onto\n",
+    "ref_specificity = specificity_score(ref_y_true, ref_pred)  # how many tn's are there"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "hp9WZ3vxoNvm"
+   },
+   "source": [
+    "## 2. Male Group\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "2c597763",
+    "outputId": "86857520-d585-4cf6-8716-7f077bfd72dc"
+   },
+   "outputs": [],
+   "source": [
+    "# Use the \"Male\" group as reference at threshold = 0.5\n",
+    "reference_group_sex = \"Male\"\n",
+    "ref_indices_sex = fairness_df[\"sex\"] == reference_group_sex\n",
+    "ref_pred_sex = (fairness_df[\"y_prob\"][ref_indices_sex] >= 0.5).astype(int)\n",
+    "ref_y_true_sex = fairness_df[\"y_true\"][ref_indices_sex]\n",
+    "\n",
+    "# Compute Baseline Metrics for Male group\n",
+    "ref_accuracy_sex = accuracy_score(ref_y_true_sex, ref_pred_sex)\n",
+    "ref_precision_sex = precision_score(ref_y_true_sex, ref_pred_sex)\n",
+    "ref_recall_sex = recall_score(ref_y_true_sex, ref_pred_sex)\n",
+    "ref_specificity_sex = specificity_score(ref_y_true_sex, ref_pred_sex)\n",
+    "\n",
+    "print(f\"Male Group Metrics (Threshold 0.5):\")\n",
+    "print(f\"Accuracy: {ref_accuracy_sex}\")\n",
+    "print(f\"Precision: {ref_precision_sex}\")\n",
+    "print(f\"Recall: {ref_recall_sex}\")\n",
+    "print(f\"Specificity: {ref_specificity_sex}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ghrEQkEo7rax"
+   },
+   "source": [
+    "## Step 3: Find Matching Thresholds for Other Group\n",
+    "### Race groups"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "9T45RcBpSAR1",
+    "outputId": "0c8f8667-3554-4ea5-f341-395e7af95afe"
+   },
+   "outputs": [],
+   "source": [
+    "# # Find group-specific thresholds that minimize difference from White group\n",
+    "# group_thresholds = {}  # stores best threshold for each race groups\n",
+    "\n",
+    "# for group in fairness_df[\"race\"].unique():  # loops through each unique race group\n",
+    "#     if group == reference_group:\n",
+    "#         group_thresholds[group] = 0.5\n",
+    "#         continue  # assigns threshold to White and skips to next group\n",
+    "\n",
+    "#     group_indices = fairness_df[\"race\"] == group  # google boolean, binary t/f\n",
+    "#     group_probs = fairness_df[\"y_prob\"][\n",
+    "#         group_indices\n",
+    "#     ].values  # predicts the groups probabilities\n",
+    "#     group_true = fairness_df[\"y_true\"][\n",
+    "#         group_indices\n",
+    "#     ].values  # actual answers/labels for this group\n",
+    "\n",
+    "#     best_threshold = 0.5\n",
+    "#     best_diff = float(\"inf\")\n",
+    "\n",
+    "#     for t in np.linspace(\n",
+    "#         0.1, 0.9, 100\n",
+    "#     ):  # loops various 100 threshold values #linear space\n",
+    "#         preds = (group_probs >= t).astype(int)  # true\n",
+    "#         acc = accuracy_score(group_true, preds)\n",
+    "\n",
+    "#         # calculates preformance metrics\n",
+    "#         prec = precision_score(group_true, preds)\n",
+    "#         rec = recall_score(group_true, preds)\n",
+    "#         spec = specificity_score(group_true, preds)\n",
+    "\n",
+    "#         # calculates total difference\n",
+    "#         diff = (\n",
+    "#             abs(acc - ref_accuracy)  # absolute value\n",
+    "#             + abs(prec - ref_precision)\n",
+    "#             + abs(rec - ref_recall)\n",
+    "#             + abs(spec - ref_specificity)\n",
+    "#         )\n",
+    "\n",
+    "#         if diff < best_diff:\n",
+    "#             best_diff = diff\n",
+    "#             best_threshold = t\n",
+    "\n",
+    "#     group_thresholds[group] = best_threshold\n",
+    "\n",
+    "group_thresholds_race = eqb.find_group_thresholds(\n",
+    "    y_true=y_test,\n",
+    "    y_prob=y_prob,\n",
+    "    reference_group=\"White\",\n",
+    "    group_vec=fairness_df[\"race\"],\n",
+    "    ref_metrics=None,\n",
+    "    threshold_range=(0.1, 0.9),\n",
+    "    n_steps=100,\n",
+    "    default_threshold=0.5,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# Display optimal thresholds per group\n",
+    "group_thresholds_race"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "NxqvMYa_58SP"
+   },
+   "source": [
+    "### Sex groups"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "745439ca",
+    "outputId": "46cc38e2-0015-46f4-ee77-86be7546debe"
+   },
+   "outputs": [],
+   "source": [
+    "# # Iterate and find best thresholds for other groups\n",
+    "# group_thresholds_sex = {}\n",
+    "\n",
+    "# for group in fairness_df[\"sex\"].unique():\n",
+    "#     if group == reference_group_sex:\n",
+    "#         group_thresholds_sex[group] = 0.5\n",
+    "#         continue\n",
+    "\n",
+    "#     group_indices_sex = fairness_df[\"sex\"] == group\n",
+    "#     group_probs_sex = fairness_df[\"y_prob\"][group_indices_sex].values\n",
+    "#     group_true_sex = fairness_df[\"y_true\"][group_indices_sex].values\n",
+    "\n",
+    "#     best_threshold_sex = 0.5\n",
+    "#     best_diff_sex = float(\"inf\")\n",
+    "\n",
+    "#     for t in np.linspace(0.1, 0.9, 100):\n",
+    "#         preds_sex = (group_probs_sex >= t).astype(int)\n",
+    "#         acc_sex = accuracy_score(group_true_sex, preds_sex)\n",
+    "#         prec_sex = precision_score(group_true_sex, preds_sex)\n",
+    "#         rec_sex = recall_score(group_true_sex, preds_sex)\n",
+    "#         spec_sex = specificity_score(group_true_sex, preds_sex)\n",
+    "\n",
+    "#         diff_sex = (\n",
+    "#             abs(acc_sex - ref_accuracy_sex)\n",
+    "#             + abs(prec_sex - ref_precision_sex)\n",
+    "#             + abs(rec_sex - ref_recall_sex)\n",
+    "#             + abs(spec_sex - ref_specificity_sex)\n",
+    "#         )\n",
+    "\n",
+    "#         if diff_sex < best_diff_sex:\n",
+    "#             best_diff_sex = diff_sex\n",
+    "#             best_threshold_sex = t\n",
+    "\n",
+    "#     group_thresholds_sex[group] = best_threshold_sex\n",
+    "\n",
+    "# Store and display group thresholds\n",
+    "print(\"Optimal thresholds per sex group:\")\n",
+    "\n",
+    "group_thresholds_sex = eqb.find_group_thresholds(\n",
+    "    y_true=y_test,\n",
+    "    y_prob=y_prob,\n",
+    "    reference_group=\"Male\",\n",
+    "    group_vec=fairness_df[\"sex\"],\n",
+    "    ref_metrics=None,\n",
+    "    threshold_range=(0.1, 0.9),\n",
+    "    n_steps=100,\n",
+    "    default_threshold=0.5,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "print(group_thresholds_sex)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "BF2wOGKOUNFO"
+   },
+   "source": [
+    "## **Signficance plots**\n",
+    "\n",
+    "- Equiboots supports statistical testing to assess significance in metrics differences.\n",
+    "\n",
+    "- Specifically the omnibus and pairwise chi-square test is used to assess significance between groups.\n",
+    "\n",
+    "- Reference groups to compare against can be provided at the initialization of the Equiboots object:\n",
+    "  - using  (reference_groups=[\"white\",\"female\"]),\n",
+    "  - otherwise the groups with highest number of observations is automatically selected\n",
+    "\n",
+    "- Below we plot the different race and sex groups and look at how their performance differs for each of these groups.\n",
+    "\n",
+    "- We conduct statistical signficance tests to determine firstly whether there is a difference between:\n",
+    "  - the groups (omnibus test) this is represented by the asterix (*),\n",
+    "  - and if significant, then we determine which groups are statistically signficance these are shown with the (▲).\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Bjj5rkLUglqa"
+   },
+   "source": [
+    "##  **Threshold-Adjusted Metrics**\n",
+    "We now apply **group-specific probability thresholds by race** to modify predictions, aiming to make key performance metrics (Accuracy, Precision, Recall, Specificity) **match those of the White group**.  \n",
+    "We then visualize those adjusted race metrics side-by-side with **unadjusted sex metrics**.\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "zPQjDSvW8ahY"
+   },
+   "source": [
+    "#**Overview**:\n",
+    " Focuses on adjusting prediction thresholds to improve fairness across racial groups. It starts by saving the original statistical test results for race and sex, allowing comparison before and after adjustment. Then, it defines custom thresholds for each race group, chosen to match the performance of the White group. A function is created to apply these group-specific thresholds to make new predictions. These adjusted predictions are added to the dataset, and a new EquiBoots object is initialized to analyze fairness again, this time using the updated predictions grouped by race. Fairness metrics like accuracy and recall are recalculated for each group based on these adjustments. The code sets up and runs statistical significance tests to check if group differences remain after threshold changes. It also uses a tool to create tables summarizing fairness metrics, highlighting differences compared to the White group. Finally, it prepares a combined summary of adjusted race results and original sex results, and generates a plot that visually compares key performance metrics across race and sex, marking areas of near-equal performance and indicating statistically significant differences. This process helps assess and improve the model’s fairness by tailoring thresholds for each group.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8mDJEzqJf3zU"
+   },
+   "source": [
+    "### Step 1: Prepare Statistical Test Results for Original (Unadjusted) Metrics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "08bde8a8",
+    "outputId": "c9c8648b-c659-4029-e9b4-e8b4f9af2abb"
+   },
+   "outputs": [],
+   "source": [
+    "# Initialize EquiBoots with labels and group information\n",
+    "eq = eqb.EquiBoots(  # maybe ask for help\n",
+    "    y_true=y_test,  # actual correct answers/labels\n",
+    "    y_prob=y_prob,  # predicted probabilities\n",
+    "    y_pred=y_pred,  # predicted class labels\n",
+    "    fairness_df=fairness_df,  # table with race and sex info of each person\n",
+    "    # figure out what fairness_vars is\n",
+    "    fairness_vars=[\n",
+    "        \"race\",\n",
+    "        \"sex\",\n",
+    "    ],  # tells equiboots to use race and sex when analyzing fairness\n",
+    ")\n",
+    "\n",
+    "# Group the data by race and sex for analysis\n",
+    "eq.grouper(\n",
+    "    groupings_vars=[\"race\", \"sex\"]\n",
+    ")  # groups data by race and sex so Equiboots analyzes how fairly the model performs for each group"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "d688d2a2"
+   },
+   "outputs": [],
+   "source": [
+    "# Configuration for statistical testing\n",
+    "test_config = {\n",
+    "    \"test_type\": \"chi_square\",\n",
+    "    \"alpha\": 0.05,\n",
+    "    \"adjust_method\": \"bonferroni\",\n",
+    "    \"confidence_level\": 0.95,\n",
+    "    \"classification_task\": \"binary_classification\",\n",
+    "}\n",
+    "\n",
+    "# Run fairness tests\n",
+    "stat_test_results_race = eq.analyze_statistical_significance(\n",
+    "    race_metrics, \"race\", test_config\n",
+    ")\n",
+    "stat_test_results_sex = eq.analyze_statistical_significance(\n",
+    "    sex_metrics, \"sex\", test_config\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "wjo6kTRSH9Nj"
+   },
+   "outputs": [],
+   "source": [
+    "# Define how we want to test for statistically significant group differences\n",
+    "test_config = {\n",
+    "    \"test_type\": \"chi_square\",  # Use Chi-squared test\n",
+    "    \"alpha\": 0.05,  # Significance level\n",
+    "    \"adjust_method\": \"bonferroni\",  # Adjust for multiple comparisons\n",
+    "    \"confidence_level\": 0.95,  # 95% confidence interval\n",
+    "    \"classification_task\": \"binary_classification\",  # Task type\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "3KYSq8E8gb_z"
+   },
+   "outputs": [],
+   "source": [
+    "# Prepare statistical test results for original (unadjusted) metrics\n",
+    "# Make sure to run the cell above this one (cell ID 9907ff14) to define stat_test_results_sex and stat_test_results_race\n",
+    "overall_stat_results = {\n",
+    "    \"sex\": stat_test_results_sex,\n",
+    "    \"race\": stat_test_results_race,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "sHi4uyobgd9K"
+   },
+   "source": [
+    "### Step 2: Define Race-Specific Thresholds\n",
+    "These thresholds were determined by minimizing the difference in performance compared to the White reference group."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "fgZnl-u89cgh"
+   },
+   "outputs": [],
+   "source": [
+    "# Manually defined thresholds for each race group (based on prior optimization)\n",
+    "group_thresholds_race = {\n",
+    "    \"White\": 0.5,\n",
+    "    \"Black\": 0.407070707070707,\n",
+    "    \"Asian-Pac-Islander\": 0.4232323232323232,\n",
+    "    \"Amer-Indian-Eskimo\": 0.41515151515151516,\n",
+    "    \"Other\": 0.2535353535353535,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "x5IrEAvsqQig"
+   },
+   "outputs": [],
+   "source": [
+    "# Manually defined thresholds for each sex group (based on prior optimization)\n",
+    "group_thresholds_sex = {\n",
+    "    \"Male\": 0.5,\n",
+    "    \"Female\": 0.4313131313131313,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "h3DPoW91g9MY"
+   },
+   "source": [
+    "### Step 3: Define a Function to Apply Group-Specific Thresholds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "VapmluVcg8vy"
+   },
+   "outputs": [],
+   "source": [
+    "# # This function applies custom thresholds for each group based on their group label\n",
+    "# def grouped_threshold_predict(\n",
+    "#     y_prob, group_labels, group_thresholds, default_threshold=0.5\n",
+    "# ):\n",
+    "#     predictions = np.zeros_like(\n",
+    "#         y_prob, dtype=int\n",
+    "#     )  # Initialize array of 0s for predicted labels\n",
+    "#     for group in np.unique(\n",
+    "#         group_labels\n",
+    "#     ):  # Loop over each unique group (e.g., each race)\n",
+    "#         idx = group_labels == group  # Get indices where group label matches\n",
+    "#         threshold = group_thresholds.get(\n",
+    "#             group, default_threshold\n",
+    "#         )  # Use custom or default threshold\n",
+    "#         predictions[idx] = (y_prob[idx] >= threshold).astype(\n",
+    "#             int\n",
+    "#         )  # Apply threshold to get predictions\n",
+    "#     return predictions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "m-jmbfKphwUo"
+   },
+   "source": [
+    "### Step 4: Apply Grouped Thresholds to Make New Predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "PxBW-6fnGjmM"
+   },
+   "outputs": [],
+   "source": [
+    "# Extract race labels for each instance in the dataset\n",
+    "race_labels = fairness_df[\"race\"].values\n",
+    "\n",
+    "# Get new predictions using group-specific thresholds\n",
+    "y_pred_grouped_thresh = eqb.grouped_threshold_predict(\n",
+    "    y_prob, race_labels, group_thresholds_race\n",
+    ")\n",
+    "\n",
+    "# Save new predictions in the fairness DataFrame\n",
+    "fairness_df[\"y_pred_grouped_thresh\"] = y_pred_grouped_thresh"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "DNTgtWkBh5Ky"
+   },
+   "source": [
+    "### Step 5: Create New EquiBoots Object for Adjusted Predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "alYxXozkBw87",
+    "outputId": "e4ee415b-4cfc-41ad-f648-3fea80b883bf"
+   },
+   "outputs": [],
+   "source": [
+    "# Create a new EquiBoots object using the adjusted predictions\n",
+    "eq_adjusted = eqb.EquiBoots(\n",
+    "    y_true=fairness_df[\"y_true\"],  # True labels\n",
+    "    y_prob=fairness_df[\"y_prob\"],  # Predicted probabilities\n",
+    "    y_pred=fairness_df[\"y_pred_grouped_thresh\"],  # Adjusted predictions\n",
+    "    fairness_df=fairness_df,  # Dataset with sensitive attributes\n",
+    "    fairness_vars=[\"race\"],  # Focus fairness analysis on race\n",
+    ")\n",
+    "\n",
+    "# Re-group the data by race (prepares for fairness slicing)\n",
+    "eq_adjusted.grouper(groupings_vars=[\"race\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "kM_IrIsliLVI"
+   },
+   "source": [
+    "### Step 6: Slice and Evaluate New Metrics by Race"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "cT32evzhiQ73"
+   },
+   "outputs": [],
+   "source": [
+    "# Extract subgroup data by race\n",
+    "sliced_race_data_adjusted = eq_adjusted.slicer(\"race\")\n",
+    "\n",
+    "# Compute fairness performance metrics for each racial group using adjusted predictions\n",
+    "race_metrics_adjusted = eq_adjusted.get_metrics(sliced_race_data_adjusted)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qEsANkeIiaqv"
+   },
+   "source": [
+    "### Step 7: Run Statistical Significance Tests for Adjusted Predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "sUlvvjgZSJX6",
+    "outputId": "730d92ed-e676-4eae-a713-3720b7e082e6"
+   },
+   "outputs": [],
+   "source": [
+    "# Create adjusted predictions using race-specific thresholds\n",
+    "race_labels = fairness_df[\"race\"].values\n",
+    "y_pred_grouped_thresh = eqb.grouped_threshold_predict(\n",
+    "    y_prob, race_labels, group_thresholds_race\n",
+    ")\n",
+    "\n",
+    "# Update fairness_df with adjusted predictions\n",
+    "fairness_df[\"y_pred_grouped_thresh\"] = y_pred_grouped_thresh\n",
+    "\n",
+    "# Instantiate new EquiBoots object using thresholded predictions\n",
+    "eq_adjusted = eqb.EquiBoots(\n",
+    "    y_true=fairness_df[\"y_true\"],\n",
+    "    y_prob=fairness_df[\"y_prob\"],\n",
+    "    y_pred=fairness_df[\"y_pred_grouped_thresh\"],\n",
+    "    fairness_df=fairness_df,\n",
+    "    fairness_vars=[\"race\"],\n",
+    ")\n",
+    "\n",
+    "# Group by race for adjusted metrics\n",
+    "eq_adjusted.grouper(groupings_vars=[\"race\"])\n",
+    "\n",
+    "# Evaluate adjusted metrics by race\n",
+    "sliced_race_data_adjusted = eq_adjusted.slicer(\"race\")\n",
+    "race_metrics_adjusted = eq_adjusted.get_metrics(sliced_race_data_adjusted)\n",
+    "\n",
+    "# Run statistical significance tests on adjusted race metrics\n",
+    "test_config = {\n",
+    "    \"test_type\": \"chi_square\",\n",
+    "    \"alpha\": 0.05,\n",
+    "    \"adjust_method\": \"bonferroni\",\n",
+    "    \"confidence_level\": 0.95,\n",
+    "    \"classification_task\": \"binary_classification\",\n",
+    "}\n",
+    "stat_test_results_adjusted = eq_adjusted.analyze_statistical_significance(\n",
+    "    race_metrics_adjusted, \"race\", test_config\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "59VX9U4ii9ND"
+   },
+   "source": [
+    "### Step 8: Combine Adjusted and Original Metrics for Final Plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "5fbea03d"
+   },
+   "outputs": [],
+   "source": [
+    "# Combine updated race metrics and original sex metrics for a final fairness plot\n",
+    "overall_stat_results_adjusted = {\n",
+    "    \"race\": stat_test_results_adjusted,  # Adjusted test results for race\n",
+    "    \"sex\": stat_test_results_sex,  # Original test results for sex\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 965
+    },
+    "id": "DiZ5YPCSJMtZ",
+    "outputId": "8fb12867-2559-48f0-b404-10e1246f834e"
+   },
+   "outputs": [],
+   "source": [
+    "# Plot the group performance metrics for both race (adjusted) and sex (original)\n",
+    "eqb.eq_group_metrics_point_plot(\n",
+    "    group_metrics=[race_metrics_adjusted, sex_metrics],  # Grouped metrics to compare\n",
+    "    metric_cols=[\"Accuracy\", \"Precision\", \"Recall\"],  # Metrics to plot\n",
+    "    category_names=[\"race\", \"sex\"],  # Categories to compare\n",
+    "    figsize=(8, 8),  # Size of the plot\n",
+    "    include_legend=True,  # Show legend\n",
+    "    plot_thresholds=(0.9, 1.1),  # Highlight near-equality\n",
+    "    raw_metrics=True,  # Use raw (not normalized) values\n",
+    "    show_grid=True,  # Add grid to plot\n",
+    "    y_lim=(0, 1),  # Set y-axis limits\n",
+    "    statistical_tests=overall_stat_results_adjusted,  # Display statistical test results\n",
+    "    y_lims={  # Customize Y-axis for each group/metric\n",
+    "        (\"sex\", \"Accuracy\"): (0.70, 1.0),\n",
+    "        (\"sex\", \"Precision\"): (0.70, 1.0),\n",
+    "        (\"sex\", \"Recall\"): (0.70, 1.0),\n",
+    "        (\"race\", \"Accuracy\"): (0.70, 1.0),\n",
+    "        (\"race\", \"Precision\"): (0.70, 1.0),\n",
+    "        (\"race\", \"Recall\"): (0.70, 1.0),\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "OY8ELENUYAr6"
+   },
+   "outputs": [],
+   "source": [
+    "from equiboots.tables import metrics_table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "47IeJfgYX5fN"
+   },
+   "outputs": [],
+   "source": [
+    "stat_metrics_table_point = metrics_table(\n",
+    "    race_metrics, statistical_tests=stat_test_results_race, reference_group=\"White\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 488
+    },
+    "id": "QvB6iZvPYBKW",
+    "outputId": "76dfdc19-3b3a-4055-e95f-b8b3fefb0fed"
+   },
+   "outputs": [],
+   "source": [
+    "# table with metrics per group and statistical significance shown on columns for\n",
+    "# omnibus and/or pairwise\n",
+    "stat_metrics_table_point"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 321
+    },
+    "id": "MItQKuJQOt_u",
+    "outputId": "2cabfdbe-ed19-4c5c-e366-47d4fbc5b3df"
+   },
+   "outputs": [],
+   "source": [
+    "# from google.colab import sheets\n",
+    "\n",
+    "# # Make sure to run the cell above this one (QvB6iZvPYBKW) to define stat_metrics_table_point\n",
+    "# sheet = sheets.InteractiveSheet(df=stat_metrics_table_point)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "C2fZVL_7jwRE"
+   },
+   "source": [
+    "# Conclusion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "6V6o7sSnThlo"
+   },
+   "source": [
+    "EquiBoots provides a powerful framework for evaluating and visualizing machine learning model performance across demographic groups with a focus on fairness in binary classification. In this analysis, we examined both unadjusted and threshold adjusted predictions for race and sex groups. Point estimates revealed statistically significant performance differences between the reference group (White) and others, especially for Accuracy, Precision, and Recall. While these differences were statistically significant, some had small effect sizes, suggesting limited practical impact in certain cases.\n",
+    "\n",
+    "To address disparities, we applied race specific probability thresholds to align key metrics with those of the White group. This post processing approach successfully reduced or eliminated significant differences in many metrics, particularly for Black and Asian Pacific Islander populations. Specificity and False Positive Rates also improved, demonstrating that group specific thresholds can help balance performance outcomes. Sex based metrics, which were not adjusted, were included for comparison.\n",
+    "\n",
+    "Although thresholding improved fairness metrics, it does not address deeper issues such as biases in data collection, feature design, or model training. Bootstrapped analyses further confirmed disparities, particularly within the Black population, across multiple metrics including Prevalence, Log Loss, and Brier Score. Miscalibration in groups like Asian Pacific Islander also suggests that further improvements could come from calibration techniques.\n",
+    "\n",
+    "Overall, this analysis highlights both the shortcomings of traditional evaluation methods and the value of fairness aware tools like EquiBoots. Group specific thresholding is one effective strategy to improve equity, but it should be used alongside broader efforts in fair model development and ethical deployment practices.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "9d3ee22c"
+   },
+   "source": [
+    "# Task\n",
+    "Calculate matching thresholds for sex, using males as the reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dc2c0f20"
+   },
+   "source": [
+    "## Define the reference group\n",
+    "\n",
+    "### Subtask:\n",
+    "Specify 'Male' as the reference group for calculating thresholds.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "e32652d1"
+   },
+   "source": [
+    "## Calculate reference metrics\n",
+    "\n",
+    "### Subtask:\n",
+    "Compute the performance metrics (Accuracy, Precision, Recall, Specificity) for the 'Male' group at a default threshold (e.g., 0.5).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "7704dc20"
+   },
+   "source": [
+    "**Reasoning**:\n",
+    "Compute the performance metrics (Accuracy, Precision, Recall, Specificity) for the 'Male' group at a default threshold (e.g., 0.5) as instructed in the subtask.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "b6a8580e"
+   },
+   "source": [
+    "**Reasoning**:\n",
+    "The error indicates that `fairness_df` is not defined. I need to recreate the `fairness_df` DataFrame using the `X_test` and `y_test` variables which were defined earlier in the notebook, and then proceed with calculating the performance metrics for the 'Male' group.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "6c780408"
+   },
+   "source": [
+    "### Step 5: Apply Grouped Thresholds to Make New Predictions for Sex"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "69c9a270"
+   },
+   "outputs": [],
+   "source": [
+    "# Extract sex labels for each instance in the dataset\n",
+    "sex_labels = fairness_df[\"sex\"].values\n",
+    "\n",
+    "# Get new predictions using group-specific thresholds for sex\n",
+    "y_pred_grouped_thresh_sex = eqb.grouped_threshold_predict(\n",
+    "    y_prob, sex_labels, group_thresholds_sex\n",
+    ")\n",
+    "\n",
+    "# Save new predictions in the fairness DataFrame\n",
+    "fairness_df[\"y_pred_grouped_thresh_sex\"] = y_pred_grouped_thresh_sex"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "1ba031d2"
+   },
+   "source": [
+    "### Step 6: Create New EquiBoots Object for Adjusted Sex Predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "d7c2da54",
+    "outputId": "bd507389-f98e-4bb3-dc6f-03514c57d1dd"
+   },
+   "outputs": [],
+   "source": [
+    "# Create a new EquiBoots object using the adjusted predictions for sex\n",
+    "eq_adjusted_sex = eqb.EquiBoots(\n",
+    "    y_true=fairness_df[\"y_true\"],  # True labels\n",
+    "    y_prob=fairness_df[\"y_prob\"],  # Predicted probabilities\n",
+    "    y_pred=fairness_df[\"y_pred_grouped_thresh_sex\"],  # Adjusted predictions for sex\n",
+    "    fairness_df=fairness_df,  # Dataset with sensitive attributes\n",
+    "    fairness_vars=[\"sex\"],  # Focus fairness analysis on sex\n",
+    ")\n",
+    "\n",
+    "# Re-group the data by sex (prepares for fairness slicing)\n",
+    "eq_adjusted_sex.grouper(groupings_vars=[\"sex\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "df089765"
+   },
+   "source": [
+    "### Step 7: Slice and Evaluate New Metrics by Sex"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "73ff447d"
+   },
+   "outputs": [],
+   "source": [
+    "# Extract subgroup data by sex\n",
+    "sliced_sex_data_adjusted = eq_adjusted_sex.slicer(\"sex\")\n",
+    "\n",
+    "# Compute fairness performance metrics for each sex group using adjusted predictions\n",
+    "sex_metrics_adjusted = eq_adjusted_sex.get_metrics(sliced_sex_data_adjusted)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "180da8c0"
+   },
+   "source": [
+    "### Step 8: Run Statistical Significance Tests for Adjusted Sex Predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "35b4ac99"
+   },
+   "outputs": [],
+   "source": [
+    "# Run statistical significance tests on adjusted sex metrics\n",
+    "stat_test_results_sex_adjusted = eq_adjusted_sex.analyze_statistical_significance(\n",
+    "    sex_metrics_adjusted, \"sex\", test_config\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "49b7b107"
+   },
+   "source": [
+    "### Step 9: Combine Adjusted Race and Adjusted Sex Metrics for Final Plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "69eaff43"
+   },
+   "outputs": [],
+   "source": [
+    "# Combine adjusted race metrics and adjusted sex metrics for a final fairness plot\n",
+    "overall_stat_results_adjusted_both = {\n",
+    "    \"race\": stat_test_results_adjusted,  # Adjusted test results for race\n",
+    "    \"sex\": stat_test_results_sex_adjusted,  # Adjusted test results for sex\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "267ccb3a"
+   },
+   "source": [
+    "### Step 10: Plot Adjusted Performance Metrics for Race and Sex"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 965
+    },
+    "id": "04fb574b",
+    "outputId": "ae37a5b9-d9ab-49ce-c19d-880a1d0e8129"
+   },
+   "outputs": [],
+   "source": [
+    "# Plot the group performance metrics for both race (adjusted) and sex (adjusted)\n",
+    "eqb.eq_group_metrics_point_plot(\n",
+    "    group_metrics=[\n",
+    "        race_metrics_adjusted,\n",
+    "        sex_metrics_adjusted,\n",
+    "    ],  # Grouped metrics to compare\n",
+    "    metric_cols=[\"Accuracy\", \"Precision\", \"Recall\"],  # Metrics to plot\n",
+    "    category_names=[\"race\", \"sex\"],  # Categories to compare\n",
+    "    figsize=(8, 8),  # Size of the plot\n",
+    "    include_legend=True,  # Show legend\n",
+    "    plot_thresholds=(0.9, 1.1),  # Highlight near-equality\n",
+    "    raw_metrics=True,  # Use raw (not normalized) values\n",
+    "    show_grid=True,  # Add grid to plot\n",
+    "    y_lim=(0, 1),  # Set y-axis limits\n",
+    "    statistical_tests=overall_stat_results_adjusted_both,  # Display statistical test results\n",
+    "    y_lims={  # Customize Y-axis for each group/metric\n",
+    "        (\"sex\", \"Accuracy\"): (0.70, 1.0),\n",
+    "        (\"sex\", \"Precision\"): (0.70, 1.0),\n",
+    "        (\"sex\", \"Recall\"): (0.70, 1.0),\n",
+    "        (\"race\", \"Accuracy\"): (0.70, 1.0),\n",
+    "        (\"race\", \"Precision\"): (0.70, 1.0),\n",
+    "        (\"race\", \"Recall\"): (0.70, 1.0),\n",
+    "    },\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "equiboots",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/src/equiboots/healer.py
+++ b/src/equiboots/healer.py
@@ -1,0 +1,132 @@
+import numpy as np
+from typing import Optional, Dict, Tuple, Union
+from sklearn.metrics import (
+    accuracy_score,
+    precision_score,
+    recall_score,
+)
+
+
+def find_group_thresholds(
+    y_true: Union[np.ndarray, list],
+    y_prob: Union[np.ndarray, list],
+    group_vec: Union[np.ndarray, list],
+    reference_group: Union[str, int],
+    ref_metrics: Optional[Dict[str, float]] = None,
+    threshold_range: Tuple[float, float] = (0.1, 0.9),
+    n_steps: int = 100,
+    default_threshold: float = 0.5,
+) -> Dict[Union[str, int], float]:
+    """
+    Find per-group probability thresholds that minimize the sum of absolute
+    differences from a reference group's metrics: accuracy, precision, recall, specificity.
+
+    Parameters
+    ----------
+    y_true : array-like of shape (n_samples,)
+        Binary ground truth labels, 0 or 1.
+    y_prob : array-like of shape (n_samples,)
+        Predicted probabilities for the positive class.
+    group_vec : array-like of shape (n_samples,)
+        Group labels, e.g., race or sex for each sample.
+    reference_group : hashable
+        The group used as the baseline.
+    ref_metrics : dict or None
+        If provided, must have keys 'accuracy', 'precision', 'recall', 'specificity'.
+        If None, they are computed from the reference group at default_threshold.
+    threshold_range : tuple(float, float)
+        Inclusive range of thresholds to search.
+    n_steps : int
+        Number of thresholds to evaluate between the range endpoints.
+    default_threshold : float
+        Used for the reference group's fixed threshold and as the initial best value.
+
+    Returns
+    -------
+    dict
+        Mapping group -> optimal threshold.
+    """
+    y_true = np.asarray(y_true).ravel()
+    y_prob = np.asarray(y_prob).ravel()
+    group_vec = np.asarray(group_vec).ravel()
+
+    if not np.isin(reference_group, group_vec).any():
+        raise ValueError(f"reference_group '{reference_group}' not found in group_vec")
+
+    # Compute reference metrics if not provided
+    if ref_metrics is None:
+        ref_mask = group_vec == reference_group
+        ref_true = y_true[ref_mask]
+        ref_preds = (y_prob[ref_mask] >= default_threshold).astype(int)
+        ref_metrics = {
+            "accuracy": accuracy_score(ref_true, ref_preds),
+            "precision": precision_score(ref_true, ref_preds),
+            "recall": recall_score(ref_true, ref_preds),
+            "specificity": recall_score(ref_true, ref_preds, pos_label=0),
+        }
+
+    required = {"accuracy", "precision", "recall", "specificity"}
+    missing = required.difference(ref_metrics.keys())
+    if missing:
+        raise ValueError(f"ref_metrics missing keys: {sorted(missing)}")
+
+    thresholds = {}
+    unique_groups = np.unique(group_vec)
+
+    for g in unique_groups:
+        if g == reference_group:
+            thresholds[g] = default_threshold
+            continue
+
+        mask = group_vec == g
+        probs = y_prob[mask]
+        true = y_true[mask]
+
+        best_t = default_threshold
+        best_diff = float("inf")
+
+        for t in np.linspace(threshold_range[0], threshold_range[1], n_steps):
+            preds = (probs >= t).astype(int)
+            acc = accuracy_score(true, preds)
+            prec = precision_score(true, preds, zero_division=0)
+            rec = recall_score(true, preds, zero_division=0)
+            spec = recall_score(
+                true, preds, pos_label=0, zero_division=0
+            )  # specificity
+
+            diff = (
+                abs(acc - ref_metrics["accuracy"])
+                + abs(prec - ref_metrics["precision"])
+                + abs(rec - ref_metrics["recall"])
+                + abs(spec - ref_metrics["specificity"])
+            )
+            if diff < best_diff:
+                best_diff = diff
+                best_t = t
+
+        thresholds[g] = best_t
+
+    return thresholds
+
+
+# This function applies custom thresholds for each group based on their group label
+def grouped_threshold_predict(
+    y_prob, group_labels, group_thresholds, default_threshold=0.5
+):
+    """
+    Convert predicted probabilities to class labels using a threshold per group.
+    """
+    predictions = np.zeros_like(
+        y_prob, dtype=int
+    )  # Initialize array of 0s for predicted labels
+    for group in np.unique(
+        group_labels
+    ):  # Loop over each unique group (e.g., each race)
+        idx = group_labels == group  # Get indices where group label matches
+        threshold = group_thresholds.get(
+            group, default_threshold
+        )  # Use custom or default threshold
+        predictions[idx] = (y_prob[idx] >= threshold).astype(
+            int
+        )  # Apply threshold to get predictions
+    return predictions

--- a/unittests/test_healer.py
+++ b/unittests/test_healer.py
@@ -1,0 +1,174 @@
+import pytest
+import pandas as pd
+import numpy as np
+import pytest
+
+from src.equiboots.healer import find_group_thresholds, grouped_threshold_predict
+
+############################################################################
+# -----------------------------
+# grouped_threshold_predict
+# -----------------------------
+
+
+def test_grouped_threshold_predict_basic():
+    y_prob = np.array([0.20, 0.60, 0.40, 0.90])
+    groups = np.array(["A", "A", "B", "B"])
+    thresholds = {"A": 0.50, "B": 0.80}
+
+    preds = grouped_threshold_predict(
+        y_prob=y_prob,
+        group_labels=groups,
+        group_thresholds=thresholds,
+        default_threshold=0.5,
+    )
+    # A: [0.20, 0.60] with t=0.5 -> [0, 1]
+    # B: [0.40, 0.90] with t=0.8 -> [0, 1]
+    np.testing.assert_array_equal(preds, np.array([0, 1, 0, 1]))
+
+
+def test_grouped_threshold_predict_uses_default_for_missing_group():
+    y_prob = np.array([0.49, 0.51, 0.49, 0.51])
+    groups = np.array(["A", "A", "B", "B"])
+    thresholds = {"A": 0.75}  # no threshold for B
+    preds = grouped_threshold_predict(
+        y_prob=y_prob,
+        group_labels=groups,
+        group_thresholds=thresholds,
+        default_threshold=0.50,
+    )
+    # A uses 0.75 -> [0, 0]
+    # B uses default 0.50 -> [0, 1]
+    np.testing.assert_array_equal(preds, np.array([0, 0, 0, 1]))
+
+
+# -----------------------------
+# find_group_thresholds
+# -----------------------------
+
+
+def test_find_group_thresholds_raises_if_reference_missing():
+    y_true = np.array([0, 1, 1, 0])
+    y_prob = np.array([0.2, 0.8, 0.7, 0.3])
+    groups = np.array(["A", "A", "B", "B"])
+
+    with pytest.raises(ValueError):
+        find_group_thresholds(
+            y_true=y_true,
+            y_prob=y_prob,
+            group_vec=groups,
+            reference_group="C",  # not present
+        )
+
+
+def test_find_group_thresholds_sets_reference_to_default_threshold():
+    y_true = np.array([0, 1, 1, 0, 1, 0])
+    y_prob = np.array([0.1, 0.9, 0.8, 0.2, 0.7, 0.4])
+    groups = np.array(["A", "A", "A", "B", "B", "B"])
+
+    out = find_group_thresholds(
+        y_true=y_true,
+        y_prob=y_prob,
+        group_vec=groups,
+        reference_group="A",
+        default_threshold=0.55,
+        n_steps=25,
+        threshold_range=(0.1, 0.9),
+    )
+    # Reference group must equal the provided default_threshold
+    assert out["A"] == pytest.approx(0.55)
+
+
+def test_find_group_thresholds_works_with_provided_ref_metrics_and_changes_solution():
+    y_true = np.array([0, 1, 1, 0, 1, 0, 0, 1])
+    y_prob = np.array([0.2, 0.7, 0.8, 0.3, 0.65, 0.45, 0.35, 0.9])
+    groups = np.array(["A", "A", "A", "A", "B", "B", "B", "B"])
+
+    out_auto = find_group_thresholds(
+        y_true=y_true,
+        y_prob=y_prob,
+        group_vec=groups,
+        reference_group="A",
+        default_threshold=0.5,
+        n_steps=50,
+        threshold_range=(0.2, 0.9),
+    )
+
+    ref_metrics = {
+        "accuracy": 0.90,
+        "precision": 0.90,
+        "recall": 0.95,
+        "specificity": 0.95,
+    }
+    out_custom = find_group_thresholds(
+        y_true=y_true,
+        y_prob=y_prob,
+        group_vec=groups,
+        reference_group="A",
+        ref_metrics=ref_metrics,
+        default_threshold=0.5,
+        n_steps=50,
+        threshold_range=(0.2, 0.9),
+    )
+
+    # Still validate structure and values without requiring different argmin outcomes
+    assert set(out_auto.keys()) == {"A", "B"}
+    assert set(out_custom.keys()) == {"A", "B"}
+    assert isinstance(out_auto["A"], float) and isinstance(out_auto["B"], float)
+    assert isinstance(out_custom["A"], float) and isinstance(out_custom["B"], float)
+    assert 0.2 <= out_auto["B"] <= 0.9
+    assert 0.2 <= out_custom["B"] <= 0.9
+
+
+def test_find_group_thresholds_handles_zero_division_groups():
+    # Group B has only negatives in y_true, which would yield precision undefined
+    # The function uses zero_division=0 internally, so it should not raise
+    y_true = np.array([0, 1, 1, 0, 0, 0])
+    y_prob = np.array([0.1, 0.9, 0.8, 0.2, 0.3, 0.4])
+    groups = np.array(["A", "A", "A", "B", "B", "B"])
+
+    out = find_group_thresholds(
+        y_true=y_true,
+        y_prob=y_prob,
+        group_vec=groups,
+        reference_group="A",
+        default_threshold=0.5,
+        n_steps=30,
+        threshold_range=(0.1, 0.9),
+    )
+    # Both groups must be present and have numeric thresholds
+    assert set(out.keys()) == {"A", "B"}
+    assert isinstance(out["A"], float)
+    assert isinstance(out["B"], float)
+
+
+def test_integration_thresholds_then_apply_grouped_predict():
+    # Simple separable toy data
+    y_true = np.array([0, 1, 1, 0, 1, 0, 0, 1])
+    y_prob = np.array([0.2, 0.7, 0.8, 0.3, 0.65, 0.45, 0.35, 0.9])
+    groups = np.array(["A", "A", "A", "A", "B", "B", "B", "B"])
+    default_t = 0.5
+
+    thresholds = find_group_thresholds(
+        y_true=y_true,
+        y_prob=y_prob,
+        group_vec=groups,
+        reference_group="A",
+        default_threshold=default_t,
+        n_steps=40,
+        threshold_range=(0.2, 0.9),
+    )
+
+    preds = grouped_threshold_predict(
+        y_prob=y_prob,
+        group_labels=groups,
+        group_thresholds=thresholds,
+        default_threshold=default_t,
+    )
+
+    # Sanity: reference group A should be thresholded at default_t
+    # A indices: 0..3 -> probs [0.2, 0.7, 0.8, 0.3] -> [0, 1, 1, 0]
+    np.testing.assert_array_equal(preds[:4], np.array([0, 1, 1, 0]))
+
+    # B uses its learned threshold. We cannot hardcode it, but predictions must be 0 or 1
+    assert set(preds[4:].tolist()).issubset({0, 1})


### PR DESCRIPTION
- Added Specificity score to dictionary inside `metrics.py`
 
Introduction of two new helper functions to support post-hoc **model healing** by adjusting decision thresholds on a per-group basis:

* **`find_group_thresholds`**  
  Computes an optimal probability threshold for each group (e.g., race, sex) that minimizes the absolute difference from a reference group’s key metrics (accuracy, precision, recall, specificity).  
  Useful when you need to align performance across demographic groups.

* **`grouped_threshold_predict`**  
  Applies custom thresholds returned by `find_group_thresholds` (or any user-supplied mapping) to convert predicted probabilities into binary class labels for each group.

- updated unittests

These utilities let us fine-tune model outputs after training to reduce fairness gaps without retraining the model, supporting the 
broader goal of **model healing**.

