### PR TITLE
Minor Fix for x-axis labels not being centered under bars in `plot_effect_sizes()`

### DIFF
--- a/src/equiboots/plots.py
+++ b/src/equiboots/plots.py
@@ -1919,7 +1919,7 @@ def plot_effect_sizes(
     plt.legend()
     plt.grid(axis="y", linestyle="--")
 
-    plt.xticks(rotation=rotation, ha="right")
+    plt.xticks(rotation=rotation, ha="center")
     plt.tight_layout()
 
     # save or show


### PR DESCRIPTION
The x-axis labels in `plot_effect_sizes()` were slightly misaligned with the bar centers when using dictionary keys directly. 

Changed this line:

```python
plt.xticks(rotation=rotation, ha="right")
```

to:

```python
plt.xticks(rotation=rotation, ha="center")
```
